### PR TITLE
Fix for missing yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ buttons:
 ```
 As you can see in the `items:` line, each dropdown option links to the branch of the repository in the respective language.
 
+Note: the `_launch_buttons.yml` file is optional. If it is not present when building HTML, the extension will not install any launch-button assets and no buttons will be shown. Add `_launch_buttons.yml` to enable buttons."
+
 ### Setting up your repository for multilingual book
 
 For the implementation to your book, it is handy to create a branch for each language version you want to offer. Make a new branch using for example main as a source. Assuming we want to create a dutch version of you can call this branch `Dutch` or `Nederlands`. 

--- a/src/sphinx-launch-buttons/__init__.py
+++ b/src/sphinx-launch-buttons/__init__.py
@@ -63,6 +63,15 @@ def yaml_to_json(yaml_file: str, json_file: str) -> None:
             json.dump(data, jsonfile, indent=4)
 
 def setup(app: Sphinx) -> dict[str, str]:
-    app.add_js_file('launch_buttons.js')
-    app.connect('build-finished', copy_buttons)
+    # Only register the JS and the build-finished handler if the project provides
+    # a `_launch_buttons.yml` file. If we always add the JS, Sphinx will reference
+    # `launch_buttons.js` even when it's not copied into `_static`, causing a 404.
+    launch_buttons_yaml = os.path.join(getattr(app, 'srcdir', ''), '_launch_buttons.yml')
+    if os.path.exists(launch_buttons_yaml):
+        app.add_js_file('launch_buttons.js')
+        app.connect('build-finished', copy_buttons)
+    else:
+        # No config present: don't register assets or handlers.
+        print('[sphinx-launch-buttons] no _launch_buttons.yml found during setup; not registering assets')
+
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/src/sphinx-launch-buttons/__init__.py
+++ b/src/sphinx-launch-buttons/__init__.py
@@ -25,12 +25,34 @@ def copy_buttons(app: Sphinx, exc: None) -> None:
         launch_buttons_yaml = os.path.join(app.builder.srcdir, '_launch_buttons.yml')
     
         # Convert _launch_buttons.yaml to _launch_buttons.json so it can be read in javascript
-        yaml_to_json(launch_buttons_yaml, os.path.join(staticdir, '_launch_buttons.json'))
+        # Only proceed if the YAML exists. If it doesn't, don't copy assets or write files
+        # so no buttons will be shown in the frontend.
+        if not os.path.exists(launch_buttons_yaml):
+            print(f"[sphinx-launch-buttons] no _launch_buttons.yml found; skipping asset install.")
+            return
 
-        # Copy custom.js from static
-        copy_asset_file(js_file, staticdir)
-        # copy_asset_file(launch_buttons_json, staticdir)
-        copy_asset_file(launch_buttons_yaml, staticdir)
+        # Ensure the static directory exists
+        try:
+            os.makedirs(staticdir, exist_ok=True)
+        except Exception:
+            print(f"[sphinx-launch-buttons] could not create static dir: {staticdir}")
+
+        json_target = os.path.join(staticdir, '_launch_buttons.json')
+
+        try:
+            yaml_to_json(launch_buttons_yaml, json_target)
+        except Exception as e:
+            print(f"[sphinx-launch-buttons] error converting yaml to json: {e}")
+
+        # Copy the JS and YAML assets
+        try:
+            copy_asset_file(js_file, staticdir)
+        except Exception as e:
+            print(f"[sphinx-launch-buttons] error copying js asset: {e}")
+        try:
+            copy_asset_file(launch_buttons_yaml, staticdir)
+        except Exception as e:
+            print(f"[sphinx-launch-buttons] error copying yaml asset: {e}")
 
 # Function to convert yaml to json to prevent mixing of yaml and json for the user.
 def yaml_to_json(yaml_file: str, json_file: str) -> None:

--- a/src/sphinx-launch-buttons/static/custom.js
+++ b/src/sphinx-launch-buttons/static/custom.js
@@ -5,7 +5,14 @@ document.addEventListener('DOMContentLoaded', function() {
     // Fetch json file with launch buttons
     fetch('_static/_launch_buttons.json')
     .then((response) => response.json())
-    .then((response) => addButtons(response.custom_launch_buttons));
+    .then((response) => {
+        if(!response || !Array.isArray(response.custom_launch_buttons) || response.custom_launch_buttons.length === 0) return;
+        addButtons(response.custom_launch_buttons);
+    })
+    .catch((err) => {
+        // Missing or malformed JSON — nothing to do.
+        console.debug('sphinx-launch-buttons: no valid custom_launch_buttons JSON found', err);
+    });
 
 });
 

--- a/src/sphinx-launch-buttons/static/launch_buttons.js
+++ b/src/sphinx-launch-buttons/static/launch_buttons.js
@@ -13,7 +13,14 @@ display: block; /* Display the dropdown menu on hover */
 document.addEventListener('DOMContentLoaded', function() {
     fetch('_static/_launch_buttons.json')
     .then((response) => response.json())
-    .then((response) => addButtons(response.buttons));
+    .then((response) => {
+        if(!response || !Array.isArray(response.buttons) || response.buttons.length === 0) return;
+        addButtons(response.buttons)
+    })
+    .catch((err) => {
+        // If the file is missing or malformed, do nothing — no buttons should be shown.
+        console.debug('sphinx-launch-buttons: no valid launch buttons JSON found', err);
+    });
 
 });
 


### PR DESCRIPTION
Fixed missing yaml

This pull request improves the robustness of the Sphinx launch buttons extension by making the inclusion of launch buttons optional and preventing errors when the configuration file is missing or malformed. The changes ensure that assets and frontend code are only installed and executed when `_launch_buttons.yml` is present, resulting in a more reliable and user-friendly experience.

**Optional launch buttons configuration:**

* The extension now checks for the existence of `_launch_buttons.yml` before installing assets or registering frontend handlers, so no buttons will be shown if the file is missing. This is documented in `README.md` and implemented in `__init__.py`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74-R75) [[2]](diffhunk://#diff-de29a7abe5bd1c837ab33d83cbcea4346f57c5f95853552a3e862b933f5e371aL28-R55) [[3]](diffhunk://#diff-de29a7abe5bd1c837ab33d83cbcea4346f57c5f95853552a3e862b933f5e371aR66-R76)

**Error handling and asset management:**

* Improved error handling in `copy_buttons` to catch and log exceptions when converting YAML to JSON or copying assets, preventing build failures.
* The frontend JS (`custom.js` and `launch_buttons.js`) now gracefully handles missing or malformed JSON files by checking for valid button data before rendering and logging debug messages instead of throwing errors. [[1]](diffhunk://#diff-f8f7e56a0c54563cf5187554fa2fd4d721a70048d9404e53db57ca8e90212a3fL8-R15) [[2]](diffhunk://#diff-d9a98c33643ea1703f418a42a5902860966565ed884561b356ec1e7ca3e6e6c2L16-R23)

Tested here:
- old version breaks: https://github.com/Tom-van-Woudenberg/test_sphinx_launch/actions/runs/18339950425
- New version works with button: https://tom-van-woudenberg.github.io/test_sphinx_launch/test_with_button
- New version works without button: https://tom-van-woudenberg.github.io/test_sphinx_launch/test_with_fix