### PR TITLE
Fix relative url

### DIFF
--- a/src/sphinx-launch-buttons/static/custom.js
+++ b/src/sphinx-launch-buttons/static/custom.js
@@ -3,11 +3,13 @@
 
 document.addEventListener('DOMContentLoaded', function() {
     // Fetch json file with launch buttons
-    // Use DOCUMENTATION_OPTIONS.URL_ROOT to construct the correct path from any page depth
-    const urlRoot = (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.URL_ROOT) 
-                    ? DOCUMENTATION_OPTIONS.URL_ROOT 
-                    : '../';
-    const jsonPath = urlRoot + '_static/_launch_buttons.json';
+    // Calculate the path back to root using pagename depth
+    let pathToRoot = './';
+    if (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.PAGENAME) {
+        const depth = DOCUMENTATION_OPTIONS.PAGENAME.split('/').length - 1;
+        pathToRoot = depth > 0 ? '../'.repeat(depth) : './';
+    }
+    const jsonPath = pathToRoot + '_static/_launch_buttons.json';
     
     fetch(jsonPath)
     .then((response) => response.json())

--- a/src/sphinx-launch-buttons/static/custom.js
+++ b/src/sphinx-launch-buttons/static/custom.js
@@ -3,7 +3,13 @@
 
 document.addEventListener('DOMContentLoaded', function() {
     // Fetch json file with launch buttons
-    fetch('_static/_launch_buttons.json')
+    // Use DOCUMENTATION_OPTIONS.URL_ROOT to construct the correct path from any page depth
+    const urlRoot = (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.URL_ROOT) 
+                    ? DOCUMENTATION_OPTIONS.URL_ROOT 
+                    : '../';
+    const jsonPath = urlRoot + '_static/_launch_buttons.json';
+    
+    fetch(jsonPath)
     .then((response) => response.json())
     .then((response) => {
         if(!response || !Array.isArray(response.custom_launch_buttons) || response.custom_launch_buttons.length === 0) return;

--- a/src/sphinx-launch-buttons/static/custom.js
+++ b/src/sphinx-launch-buttons/static/custom.js
@@ -5,8 +5,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // Fetch json file with launch buttons
     // Calculate the path back to root using pagename depth
     let pathToRoot = './';
-    if (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.PAGENAME) {
-        const depth = DOCUMENTATION_OPTIONS.PAGENAME.split('/').length - 1;
+    if (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.pagename) {
+        const depth = DOCUMENTATION_OPTIONS.pagename.split('/').length - 1;
         pathToRoot = depth > 0 ? '../'.repeat(depth) : './';
     }
     const jsonPath = pathToRoot + '_static/_launch_buttons.json';

--- a/src/sphinx-launch-buttons/static/launch_buttons.js
+++ b/src/sphinx-launch-buttons/static/launch_buttons.js
@@ -13,8 +13,8 @@ display: block; /* Display the dropdown menu on hover */
 document.addEventListener('DOMContentLoaded', function() {
     // Calculate the path back to root using pagename depth
     let pathToRoot = './';
-    if (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.PAGENAME) {
-        const depth = DOCUMENTATION_OPTIONS.PAGENAME.split('/').length - 1;
+    if (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.pagename) {
+        const depth = DOCUMENTATION_OPTIONS.pagename.split('/').length - 1;
         pathToRoot = depth > 0 ? '../'.repeat(depth) : './';
     }
     const jsonPath = pathToRoot + '_static/_launch_buttons.json';

--- a/src/sphinx-launch-buttons/static/launch_buttons.js
+++ b/src/sphinx-launch-buttons/static/launch_buttons.js
@@ -11,12 +11,13 @@ display: block; /* Display the dropdown menu on hover */
 
 // MAIN => hook into the DOM and add the buttons
 document.addEventListener('DOMContentLoaded', function() {
-    // Use DOCUMENTATION_OPTIONS.URL_ROOT (provided by Sphinx) to construct the correct path
-    // from any page depth. Falls back to '../' if not available.
-    const urlRoot = (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.URL_ROOT) 
-                    ? DOCUMENTATION_OPTIONS.URL_ROOT 
-                    : '../';
-    const jsonPath = urlRoot + '_static/_launch_buttons.json';
+    // Calculate the path back to root using pagename depth
+    let pathToRoot = './';
+    if (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.PAGENAME) {
+        const depth = DOCUMENTATION_OPTIONS.PAGENAME.split('/').length - 1;
+        pathToRoot = depth > 0 ? '../'.repeat(depth) : './';
+    }
+    const jsonPath = pathToRoot + '_static/_launch_buttons.json';
     
     fetch(jsonPath)
     .then((response) => response.json())

--- a/src/sphinx-launch-buttons/static/launch_buttons.js
+++ b/src/sphinx-launch-buttons/static/launch_buttons.js
@@ -11,7 +11,14 @@ display: block; /* Display the dropdown menu on hover */
 
 // MAIN => hook into the DOM and add the buttons
 document.addEventListener('DOMContentLoaded', function() {
-    fetch('_static/_launch_buttons.json')
+    // Use DOCUMENTATION_OPTIONS.URL_ROOT (provided by Sphinx) to construct the correct path
+    // from any page depth. Falls back to '../' if not available.
+    const urlRoot = (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.URL_ROOT) 
+                    ? DOCUMENTATION_OPTIONS.URL_ROOT 
+                    : '../';
+    const jsonPath = urlRoot + '_static/_launch_buttons.json';
+    
+    fetch(jsonPath)
     .then((response) => response.json())
     .then((response) => {
         if(!response || !Array.isArray(response.buttons) || response.buttons.length === 0) return;


### PR DESCRIPTION
This pull request fixes how the launch buttons JavaScript files locate the `_launch_buttons.json` configuration file. Instead of always fetching from a fixed relative path. This wasn't correct for subpages. The scripts now dynamically calculate the correct path to the JSON file based on the current documentation page's depth. This ensures the launch buttons work correctly on all documentation pages, regardless of their directory level.